### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 colorama==0.4.3
+unidecode


### PR DESCRIPTION
Could not run converter.py without installing unidecode first:

```
➜  DirectFire_Converter git:(master) python3 converter.py
Traceback (most recent call last):
  File "converter.py", line 36, in <module>
    import DirectFire.Converter.common as common
  File "/media/sf_shell1/dvx/DirectFire_Converter/DirectFire/Converter/common.py", line 7, in <module>
    import unidecode
ModuleNotFoundError: No module named 'unidecode 
```